### PR TITLE
API endpoints hosted on Deta

### DIFF
--- a/helper_functions.py
+++ b/helper_functions.py
@@ -15,7 +15,7 @@ class APINames:
 @st.cache
 def _get_json_data(endpoint):
     """
-    Gets relevant JSON data from FastAPI endpoint
+    Gets relevant JSON data from given FastAPI endpoint
     """
     response = requests.get(endpoint)
     response.raise_for_status()
@@ -23,8 +23,25 @@ def _get_json_data(endpoint):
 
 
 @st.cache
-def get_monster_list(endpoint: str) -> list[dict]:
-    return _get_json_data(endpoint)
+def get_monster_list() -> list[dict]:
+    return _get_json_data(APINames.API_GET_MONSTER_LIST)
+
+
+@st.cache
+def get_monster(monster_id) -> list[dict]:
+    return _get_json_data(APINames.API_GET_MONSTER + str(int(monster_id)))
+
+
+@st.cache
+def get_breeding_results(monster_id) -> list[dict]:
+    return _get_json_data(
+        APINames.API_GET_BREEDING_COMBO + str(int(monster_id))
+    )
+
+
+@st.cache
+def get_skills_list() -> list[dict]:
+    return _get_json_data(APINames.API_GET_SKILLS_LIST)
 
 
 @st.cache

--- a/pages/2_monster_list.py
+++ b/pages/2_monster_list.py
@@ -1,12 +1,12 @@
 import streamlit as st
-from helper_functions import APINames, get_monster_list
+from helper_functions import get_monster_list
 
 # dummy data with test files
 # with open('json_test_files/read_monsters.json') as json_file:
 #     monster_list = json.load(json_file)
 
 # FastAPI connection
-monster_list = get_monster_list(APINames.API_GET_MONSTER_LIST)
+monster_list = get_monster_list()
 
 st.markdown("## Monster List")
 name_search = st.text_input("Search by Name")

--- a/pages/3_monster_detail.py
+++ b/pages/3_monster_detail.py
@@ -1,5 +1,5 @@
 import streamlit as st
-from helper_functions import APINames, _get_json_data
+from helper_functions import get_monster, get_breeding_results
 
 st.markdown("## Monster Detail Info Page Example")
 
@@ -13,8 +13,8 @@ else:
     )
 
 if monster_id:
-    monster_data = _get_json_data(APINames.API_GET_MONSTER + str(int(monster_id)))
-    breeding_data = _get_json_data(APINames.API_GET_BREEDING_COMBO + str(int(monster_id)))
+    monster_data = get_monster(monster_id)
+    breeding_data = get_breeding_results(monster_id)
 
 # dummy test data
 # with open('json_test_files/monsterandskill_example.json') as json_file:

--- a/pages/4_skills_list.py
+++ b/pages/4_skills_list.py
@@ -1,7 +1,7 @@
 import streamlit as st
-from helper_functions import APINames, _get_json_data
+from helper_functions import get_skills_list
 
 st.markdown("## Skills Table")
 
-skill_data = _get_json_data(APINames.API_GET_SKILLS_LIST)
+skill_data = get_skills_list()
 st.dataframe(skill_data)


### PR DESCRIPTION
I created a Deta account and deployed the FastAPI on Deta like in the tutorial (https://fastapi.tiangolo.com/deployment/deta/)

Ran into a small problem with the requirements.txt file in the FastAPI repo since it wasn't encoded in utf-8 (https://docs.deta.sh/docs/common_issues/#addingupdating-dependencies-fails-with-no-output). 

FastAPI with Swagger UI should work in the following link (https://em4lp8.deta.dev/docs).

You only need to run streamlit locally with `streamlit run Home.py` and it should get JSON file from Deta.
