### PR TITLE
fix: static pathway to image and display on monster_detail

### DIFF
--- a/helper_functions.py
+++ b/helper_functions.py
@@ -11,6 +11,7 @@ class APINames:
     API_GET_SKILLS_LIST = API_BASE + "/dqm1/skills/"
     API_GET_SKILL = API_GET_SKILLS_LIST
     API_GET_ITEMS_LIST = API_BASE + "/dqm1/items/"
+    API_GET_MONSTER_IMAGE = API_BASE + "/static/images/dqm1monsters/"
 
 
 def hide_table_index():

--- a/pages/3_monster_detail.py
+++ b/pages/3_monster_detail.py
@@ -1,5 +1,5 @@
 import streamlit as st
-from helper_functions import get_monster, get_breeding_results
+from helper_functions import get_monster, get_breeding_results, APINames
 
 # TODO refactor to make it readable
 
@@ -18,8 +18,7 @@ if monster_id:
     monster_data = get_monster(monster_id)
     breeding_data = get_breeding_results(monster_id)
 
-st.image("https://lh3.googleusercontent.com/cdNCaeyTOJ1ynJkTn9-wpZJIAFHiej1-DGvGHq1us3JTPwZtcII7bbUBr0Fpaqhh8pIXBou2__z-I1yPc85mBS-EYuoTnDNRZHaT3sxU81T6=w200-s0")
-st.caption("Image is a placeholder")
+st.image(f"{APINames.API_GET_MONSTER_IMAGE}{monster_data['old_name']}.png")
 
 # Monster Info
 st.write("##### Basic Info")


### PR DESCRIPTION
Added static file images to FastAPI repo https://github.com/cmsato09/DQMonstersDB-API/tree/final-refactor and deployed on Deta. 

Basically treated the static file location as a URL similar to the API endpoints. Probably not the best way, but it should work.
Monster detail page is now in its full form! 99% to MVP!

Next steps: 
- add more game info (so not really code related)
- deploy to streamlit app
- get feedback from a subreddit