### PR TITLE
fix: third column for breeding combo

### DIFF
--- a/pages/2_monster_list.py
+++ b/pages/2_monster_list.py
@@ -53,7 +53,12 @@ if __name__ == "__main__":
                                       family_searchbox)
     hide_table_index()
 
-    st.write(
-        monster_list.to_html(escape=False, index=True),
-        unsafe_allow_html=True
-    )
+    name_column, family_column = st.columns(2)
+    name_column.write("##### **NAME**")
+    family_column.write("##### **FAMILY**")
+
+    # st.writing a df gives adjustable column width instead of a fixed width
+    # column, therefore iterating through dataframe
+    for index, info in monster_list.iterrows():
+        name_column.write(info[0], unsafe_allow_html=True)
+        family_column.write(info[1])

--- a/pages/3_monster_detail.py
+++ b/pages/3_monster_detail.py
@@ -39,18 +39,22 @@ st.write('\n')
 
 #  Start of Breeding Combo Table
 st.write("##### Breeding Combinations")
-pedigree_column, partner_column = st.columns(2)
+pedigree_column, partner_column, result_column = st.columns(3)
 pedigree_column.markdown("##### Pedigree")
 partner_column.markdown("##### Partner")
+result_column.markdown("##### Resulting Child")
 
 for combo_entry in breeding_data:
     if combo_entry['pedigree_id']:
         idx = combo_entry['pedigree']['id']
         name = combo_entry['pedigree']['old_name']
-        pedigree_column.write(
-            f"<a target='_self' href='monster_detail?id={idx}'>{name}</a>",
-            unsafe_allow_html=True
-        )
+        if idx == monster_data['id']:
+            pedigree_column.write(name)
+        else:
+            pedigree_column.write(
+                f"<a target='_self' href='monster_detail?id={idx}'>{name}</a>",
+                unsafe_allow_html=True
+            )
     else:
         pedigree_column.write(
             combo_entry['pedigree_family']['family_eng'] + " FAMILY"
@@ -59,9 +63,22 @@ for combo_entry in breeding_data:
     if combo_entry['parent2_id']:
         idx = combo_entry['parent2']['id']
         name = combo_entry['parent2']['old_name']
-        partner_column.write(
+        if idx == monster_data['id']:
+            partner_column.write(name)
+        else:
+            partner_column.write(
+                f"<a target='_self' href='monster_detail?id={idx}'>{name}</a>",
+                unsafe_allow_html=True
+            )
+    else:
+        partner_column.write(combo_entry['family2']['family_eng'] + " FAMILY")
+
+    if combo_entry['child_id'] == monster_data['id']:
+        result_column.write(combo_entry['child']['old_name'])
+    else:
+        idx = combo_entry['child']['id']
+        name = combo_entry['child']['old_name']
+        result_column.write(
             f"<a target='_self' href='monster_detail?id={idx}'>{name}</a>",
             unsafe_allow_html=True
         )
-    else:
-        partner_column.write(combo_entry['family2']['family_eng'] + " FAMILY")


### PR DESCRIPTION
- added third 'result' column in breeding combo table in monster detail
- API slightly changed to include all breeding combinations for displayed monster, so needed 'result' column
- changed adjusting column width in monster list to fixed column width